### PR TITLE
Add auth configuration to the neo4j docker snippet in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Install and setup a Neo4j server.
           --publish=7474:7474 --publish=7687:7687 \
           --volume=$HOME/neo4j/data:/data \
           --volume=$HOME/neo4j/logs:/logs \
+          --env NEO4J_AUTH=neo4j/secret \
           neo4j:3.4
 
 ## Build


### PR DESCRIPTION
Stumbled upon this when trying to run the project in default configuration.